### PR TITLE
Refactor workflows: speed up arm64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           release_name: Release ${{ github.ref_name }}
           body: |
             Release of version ${{ github.ref_name }}.
-            The server_homedir_<arch>.zip artifacts contain the pre-packaged dotfiles and tools for each architecture.
+            The server_homedir_*arch*.zip artifacts contain the pre-packaged dotfiles and tools for each architecture.
           draft: false
           prerelease: false
 
@@ -57,10 +57,15 @@ jobs:
 
   build-and-upload:
     needs: create-release
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm  # GitHub's native ARM64 runners
+
+    runs-on: ${{ matrix.runner }}
 
     permissions:
       contents: write
@@ -68,9 +73,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,17 +10,19 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm  # GitHub's native ARM64 runners
+    
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ COPY setup.sh ./setup.sh
 RUN bash ./setup.sh
 
 
-FROM --platform=amd64 ubuntu:latest
+FROM ubuntu:latest
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install only the necessary RUNTIME dependencies.


### PR DESCRIPTION
- use native arm64 runner for arm64 build instead of emulation
- don't hardcode amd64 in Dockerfile's last stage